### PR TITLE
Bump numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy<2",
+    "numpy",
     "accelerate>=0.30",
     "torch>=2.2",
     "torchvision>=0.17",


### PR DESCRIPTION
This lets `numpy` be auto-resolved when imported in other packages instead of explicitly specifying a restricted version (`<2`).